### PR TITLE
line 235 url error?

### DIFF
--- a/source/chapters/23_libraries_and_modules/libraries_and_modules.rst
+++ b/source/chapters/23_libraries_and_modules/libraries_and_modules.rst
@@ -232,7 +232,7 @@ that work with the web, complex numbers, databases, and more.
   `these examples <http://arcade.academy/examples/index.html#pymunk>`_ http://www.pymunk.org/
 * wxPython: Create GUI programs, with windows, menus, and more. http://www.wxpython.org/
 * pydot: Generate complex directed and non-directed graphs http://code.google.com/p/pydot/
-* NumPy: Sophisticated library for working with matrices. http://numpy.scipy.org/
+* NumPy: Sophisticated library for working with matrices. http://numpy.org/
 * Pandas: A library for data analysis. https://pandas.pydata.org/
 * Pillow: Work with images. https://pillow.readthedocs.io/en/latest/
 * Pyglet: Another graphics library. Arcade uses this library. https://bitbucket.org/pyglet/pyglet/wiki/Home


### PR DESCRIPTION
line235  NumPy: Sophisticated library for working with matrices. http://numpy.scipy.org/
"http://numpy.scipy.org/" should be "http://numpy.org/" 
There is another library called "Scipy" http://www.scipy.org