### PR TITLE
Use SCREEN_WIDTH and SCREEN_HEIGHT constants in class instantiation

### DIFF
--- a/source/chapters/18_window_class/ball_class_example.py
+++ b/source/chapters/18_window_class/ball_class_example.py
@@ -67,7 +67,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(640, 480, "Drawing Example")
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, "Drawing Example")
 
     arcade.run()
 

--- a/source/chapters/18_window_class/ball_list_example.py
+++ b/source/chapters/18_window_class/ball_list_example.py
@@ -83,7 +83,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(640, 480, "Drawing Example")
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, "Drawing Example")
 
     arcade.run()
 


### PR DESCRIPTION
I believe we should use `SCREEN_WIDTH` and `SCREEN_HEIGHT` to create an instance of the `MyGame` class. Otherwise, the conditions in the `update()` method of the `Ball` class don't work correctly. As a alternative I'd move the logic related to the movement of the ball to the `MyGame` class.